### PR TITLE
Reduce original Dataframe on selected metrics

### DIFF
--- a/metrics/runner.py
+++ b/metrics/runner.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     size_df = len(df_origin)
 
     df_anon = df_anon.loc[df_anon['id'] != "DEL"]
-    if args.script in ["utility_tuile", "utility_POI"]:
+    if args.script not in ["utility_tuile", "utility_POI", "utility_meet"]:
         df_origin = df_origin.loc[df_anon.index]
 
     score = 0


### PR DESCRIPTION
In order to be consistent with the server, the reduced dataframe is only used in dateUtil, hourUtil and utility_distance
- References #66